### PR TITLE
Better shape for burger buns

### DIFF
--- a/burger_buns.md
+++ b/burger_buns.md
@@ -28,7 +28,7 @@ MEASURE EVERYTHING OUT BY GRAM
 - 5-8 mins of kneading after everything is together
 - Rise 1 hour or until doubled
 - Divide into 6 or 8 buns
-- Shape by rolling, getting a sphere is CRITICAL
+- Shape by rolling, then press into a puck
 - Rise 1-2 hours or until doubled (likely closer to 1)
 - Egg wash (1 whole egg + splash of milk)
 - Bake 375 F 16-18 mins

--- a/burger_buns.md
+++ b/burger_buns.md
@@ -28,7 +28,7 @@ MEASURE EVERYTHING OUT BY GRAM
 - 5-8 mins of kneading after everything is together
 - Rise 1 hour or until doubled
 - Divide into 6 or 8 buns
-- Shape by rolling, then press into a puck
+- Shape by rolling, then press into a puck with hands about 4 inches in diameter
 - Rise 1-2 hours or until doubled (likely closer to 1)
 - Egg wash (1 whole egg + splash of milk)
 - Bake 375 F 16-18 mins


### PR DESCRIPTION
The spherical shaping of burger buns was making them too small for veggie burgers and such.  Patting them down into a puck makes them wider without sacrificing much on the height.