### PR TITLE
Remove unused burger bun steps

### DIFF
--- a/burger_buns.md
+++ b/burger_buns.md
@@ -30,6 +30,5 @@ MEASURE EVERYTHING OUT BY GRAM
 - Divide into 6 or 8 buns
 - Shape by rolling, getting a sphere is CRITICAL
 - Rise 1-2 hours or until doubled (likely closer to 1)
-- Egg wash (1 whole egg + splash of milk)
+- Egg wash (1 whole egg whisked with a fork)
 - Bake 375 F 16-18 mins
-- Brush with melted butter


### PR DESCRIPTION
We haven't been using milk in our egg washes or brushing them with butter after they come out of the oven for the last several batches and they've turned out really good, so let's remove the step entirely.